### PR TITLE
Fixed download issue, added version request functionality

### DIFF
--- a/githubFetch.m
+++ b/githubFetch.m
@@ -7,9 +7,11 @@ function filestr = githubFetch(user, repository, downloadType, name)
 %       downloadType: 'branch', 'release' or 'version'
 %       name (optional):
 %           if downloadType is 'branch': branch name (default: 'master')
-%           if downloadType is 'release': release version (default: 'latest')
+%           if downloadType is 'release' or 'version': release version (default: 'latest')
 %   Output:
-%       filestr: path to the downloaded file
+%       filestr:
+%           if downloadType is 'branch' or 'release': path to the downloaded file
+%           if downloadType is 'version': the fetched version name (no file download)
 %
 %   The downloaded file type is .zip.
 %
@@ -20,9 +22,11 @@ function filestr = githubFetch(user, repository, downloadType, name)
 %       3) githubFetch('matlab2tikz', 'matlab2tikz', 'release', '1.1.0')
 %       4) githubFetch('matlab2tikz', 'matlab2tikz', 'release')
 %       % same as githubFetch('matlab2tikz', 'matlab2tikz', 'release', 'latest')
+%       5) githubFetch('matlab2tikz', 'matlab2tikz', 'version')
+%       % fetches the latest version without downloading it
 
 %   Zoltan Csati
-%   04/02/2018
+%   11/08/2021
 
 
 
@@ -58,11 +62,11 @@ end
 if nargin < 4 % no branch or release version provided
     if branchRequested
         name = 'master';
-    elseif releaseRequested
+    elseif releaseRequested || versionRequested
         name = 'latest';
     end
 end
-if releaseRequested | versionRequested
+if releaseRequested || versionRequested
     if strcmpi(name, 'latest') % extract the latest version number
         s = urlread(fullfile(website, user, repository, 'releases', 'latest'));
         % Search based on https://stackoverflow.com/a/23756210/4892892
@@ -78,8 +82,10 @@ elseif branchRequested
     versionName = name;
 end
 
-% Download the requested branch or release (ubnless only the version number was requested)
-if ~versionRequested
+% Download the requested branch or release (unless only the version number was requested)
+if versionRequested
+    filestr = versionName;
+else
     githubLink = fullfile(website, user, repository, 'archive/refs/tags', [versionName, '.zip']);
     downloadName = [repository, '-', name, '.zip'];
     try
@@ -97,6 +103,4 @@ if ~versionRequested
             rethrow(ME);
         end
     end
-else
-    filestr = versionName;
 end


### PR DESCRIPTION
Download issue. Since the initial release of this function, GitHub has changed the release archive path:
- the release archive is now found under 'username/repository/archive/refs/tags/release.zip'
- the prefix 'v' is no longer part of the version name in the file path (x.y.zip instead of vx.y.zip)

Version Request functionality:
I am implementing this function into a Matlab App in order to automatically check for updates and download if a newer version is available. That's why I implemented a third fetch option which only returns the latest version number without downloading. I then compare this version to the currently installed one and proceed to download if the current version is outdated.
Syntax: githubFetch('matlab2tikz', 'matlab2tikz', 'version', 'latest')
Output: '1.1.0' (version number as string)